### PR TITLE
feat: hide squashed commits via branchless

### DIFF
--- a/personal-git.nix
+++ b/personal-git.nix
@@ -7,6 +7,8 @@
       new = "!f() { git checkout -b serena/$1; }; f";
       yeet =
         "!f() { git branch | grep -v ' master$' | grep -v ' main$' | xargs git branch -D; }; f";
+    squash-cleanup =
+        "!f() { git hide 'draft() - ancestors(branches())'; }; f";
     };
     extraConfig = {
       core = {


### PR DESCRIPTION
https://github.com/arxanas/git-branchless/discussions/496

tldr;  commits that are squashed aren't part of the stack and this alias finds those squashed commits and hides them from the smartlog.